### PR TITLE
Adjust valid translation conditional check

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1566,9 +1566,9 @@
       "dev": true
     },
     "node-fetch": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
     },
     "node-forge": {
       "version": "0.10.0",

--- a/src/translate-template.js
+++ b/src/translate-template.js
@@ -55,7 +55,7 @@ class TwilioFlowTranslation {
         if (!isValidState) {
           errors.push(`Could not find entry '${name}' in dictionary.`);
         } else if (!hasValidTranslation) {
-          errors.push(`Could not find ${language} translation for entry '${name}' in dictionary.`);
+          errors.push(`Could not find one more ${language} translations for entry '${name}' in dictionary.`);
         } else {
           // Validated dictionary entry, proceed with translation
           const body = Object.values(dictionary[name].dictionary[language]).join("\n");
@@ -145,7 +145,8 @@ class TwilioFlowTranslation {
   // "Private" helper functions
   static validateTranslationsForEntry(entryObject) {
     for (let key in entryObject) {
-      if (!entryObject[key] || entryObject[key].length <= 1) {
+      if (!entryObject[key] || entryObject[key].length === 0) {
+
         return false;
       }
     }

--- a/twilio-resources/post-survey-data-handler.js
+++ b/twilio-resources/post-survey-data-handler.js
@@ -138,7 +138,7 @@ exports.handler = function (context, event, callback) {
   try {
   	// * May Require Update: Update to reflect the accurate project key
     var jwtClient = new google.auth.JWT(
-      c_email,
+      context.c_email,
       null,
       `-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n`,
       scopes


### PR DESCRIPTION
Adjust the conditional check for translating templates. Specifically, allow an empty string with a space to be "OK" and not register as no translation. 